### PR TITLE
Added syntax highlighting

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,8 +18,12 @@ import {
   defaultHighlightStyle,
   foldKeymap,
   indentOnInput,
-  syntaxHighlighting
+  syntaxHighlighting,
+  StreamLanguage
 } from '@codemirror/language'
+
+import {mathjs} from "./mathjs.js"
+
 import { highlightSelectionMatches, search, searchKeymap } from '@codemirror/search'
 import {
   autocompletion,
@@ -72,6 +76,7 @@ function createCodeMirrorView(editorDiv, resultsDiv) {
   const state = EditorState.create({
     doc: initialText,
     extensions: [
+      StreamLanguage.define(mathjs),
       keymap.of([indentWithTab]),
       lintGutter(),
       lineNumbers(),

--- a/src/mathjs.js
+++ b/src/mathjs.js
@@ -1,0 +1,143 @@
+import { create, all } from 'mathjs'
+
+const math = create(all)
+//import { expression, Unit } from 'mathjs'
+
+function wordRegexp(words) {
+    return new RegExp("^((" + words.join(")|(") + "))\\b");
+}
+
+let singleOperators = new RegExp("^[\\+\\-\\*/&|\\^~<>!%']");
+let singleDelimiters = new RegExp('^[\\(\\[\\{\\},:=;\\.?]');
+let doubleOperators = new RegExp("^((==)|(!=)|(<=)|(>=)|(<<)|(>>)|(\\.[\\+\\-\\*/\\^]))");
+let doubleDelimiters = new RegExp("^((!=)|(\^\\|))");
+let tripleDelimiters = new RegExp("^((>>>)|(<<<))");
+let expressionEnd = new RegExp("^[\\]\\)]");
+let identifiers = new RegExp("^[_A-Za-z\xa1-\uffff][_A-Za-z0-9\xa1-\uffff]*");
+
+const mathFunctions = []
+const mathPhysicalConstants = []
+const mathIgnore = ['expr', 'type']
+const numberLiterals = ['e', 'E', 'i', 'Infinity', 'LN2', 'LN10', 'LOG2E', 'LOG10E', 'NaN',
+    'null', 'phi', 'pi', 'PI', 'SQRT1_2', 'SQRT2', 'tau', 'undefined', 'version']
+
+// based on https://github.com/josdejong/mathjs/blob/develop/bin/cli.js
+for (const expr in math.expression.mathWithTransform) {
+    if (!mathIgnore.includes(expr)) {
+        if (typeof math[expr] === "function") {
+            mathFunctions.push(expr)
+        } else if (!numberLiterals.includes(expr)) {
+            mathPhysicalConstants.push(expr)
+        }
+    }
+}
+
+let builtins = wordRegexp(mathFunctions);
+
+let keywords = wordRegexp(['to', 'in', 'and', 'not', 'or', 'xor', 'mod']);
+
+// generates a list of all valid units in mathjs
+let listOfUnits = []
+for (const unit in math.Unit.UNITS) {
+    for (const prefix in math.Unit.UNITS[unit].prefixes) {
+        listOfUnits.push(prefix + unit)
+    }
+}
+
+let units = wordRegexp(Array.from(new Set(listOfUnits)));
+let physicalConstants = wordRegexp(mathPhysicalConstants);
+
+// tokenizers
+function tokenTranspose(stream, state) {
+    if (!stream.sol() && stream.peek() === '\'') {
+        stream.next();
+        state.tokenize = tokenBase;
+        return 'operator';
+    }
+    state.tokenize = tokenBase;
+    return tokenBase(stream, state);
+}
+
+function tokenComment(stream, state) {
+    if (stream.match(/^.*#}/)) {
+        state.tokenize = tokenBase;
+        return 'comment';
+    };
+    stream.skipToEnd();
+    return 'comment';
+}
+
+function tokenBase(stream, state) {
+    // whitespaces
+    if (stream.eatSpace()) return null;
+
+    // Handle one line Comments
+    if (stream.match('#{')) {
+        state.tokenize = tokenComment;
+        stream.skipToEnd();
+        return 'comment';
+    }
+
+    if (stream.match(/^[#]/)) {
+        stream.skipToEnd();
+        return 'comment';
+    }
+
+    // Handle Number Literals
+    if (stream.match(/^[0-9\.+-]/, false)) {
+        if (stream.match(/^[+-]?0x[0-9a-fA-F]+[ij]?/)) {
+            stream.tokenize = tokenBase;
+            return 'number';
+        };
+        if (stream.match(/^[+-]?\d*\.\d+([EeDd][+-]?\d+)?[ij]?/)) { return 'number'; };
+        if (stream.match(/^[+-]?\d+([EeDd][+-]?\d+)?[ij]?/)) { return 'number'; };
+    }
+    if (stream.match(wordRegexp(numberLiterals))) { return 'number'; };
+
+    // Handle Strings
+    let m = stream.match(/^"(?:[^"]|"")*("|$)/) || stream.match(/^'(?:[^']|'')*('|$)/)
+    if (m) { return m[1] ? 'string' : "string error"; }
+
+    // Handle words
+    if (stream.match(keywords)) { return 'keyword'; };
+    if (stream.match(builtins)) { return 'builtin'; };
+    if (stream.match(physicalConstants)) { return 'tag'; };
+    if (stream.match(units)) { return 'attribute'; };
+    if (stream.match(identifiers)) { return 'variable'; };
+
+    if (stream.match(singleOperators) || stream.match(doubleOperators)) { return 'operator'; };
+    if (stream.match(singleDelimiters) || stream.match(doubleDelimiters) || stream.match(tripleDelimiters)) { return null; };
+
+    if (stream.match(expressionEnd)) {
+        state.tokenize = tokenTranspose;
+        return null;
+    };
+
+
+    // Handle non-detected items
+    stream.next();
+    return 'error';
+};
+
+
+export const mathjs = {
+    name: "mathjs",
+
+    startState: function () {
+        return {
+            tokenize: tokenBase
+        };
+    },
+
+    token: function (stream, state) {
+        var style = state.tokenize(stream, state);
+        if (style === 'number' || style === 'variable') {
+            state.tokenize = tokenTranspose;
+        }
+        return style;
+    },
+
+    languageData: {
+        commentTokens: { line: "%" }
+    }
+};


### PR DESCRIPTION
Hi Jos, this is following the logic for [legacy modes](https://github.com/codemirror/legacy-modes) and adapting octave mode.

I think a more modern way (not legacy) would be to include [lezer](https://lezer.codemirror.net) but seems to complicated for me at the moment and maybe have some similarities to [mathjs parse](https://mathjs.org/docs/expressions/parsing.html)

One discrepancy is that this syntax is including multi line comments like

```
#{
Multi Line comment
#}
```
I chose to keep the same logic as octave just in case for the future.
